### PR TITLE
paygate: link to localhost api routes, not api.moov.io

### DIFF
--- a/docs/paygate/index.md
+++ b/docs/paygate/index.md
@@ -56,11 +56,11 @@ $ ./apitest -help
 
 After confirming that the services are running correctly, there are several things needed before ACH transactions can be created/processed using PayGate.  Listed below are the steps necessary:
 
-1. [Setup a Depository](https://api.moov.io/#operation/addDepository) for the Originator (ODFI)
-1. [Setup a Depository](https://api.moov.io/#operation/addDepository) for the Receiver as well (RDFI)
-1. [Setup an Originator](https://api.moov.io/#operation/addOriginator) with customer information
-1. [Setup a Receiver](https://api.moov.io/#operation/addReceivers) with customer information
-1. Then you can [create a Transfer](https://api.moov.io/#operation/addTransfer) between these two FIs
+1. [Setup a Depository](https://api.moov.io/apps/paygate/#post-/depositories) for the Originator (ODFI)
+1. [Setup a Depository](https://api.moov.io/apps/paygate/#post-/depositories) for the Receiver as well (RDFI)
+1. [Setup an Originator](https://api.moov.io/apps/paygate/#post-/originators) with customer information
+1. [Setup a Receiver](https://api.moov.io/apps/paygate/#post-/receivers) with customer information
+1. Then you can [create a Transfer](https://api.moov.io/apps/paygate/#post-/transfers) between these two FIs
 
 ### X-User-ID
 


### PR DESCRIPTION
Linking to api.moov.io is for Moov's hosted solution, but this page is more about talking directly to paygate.